### PR TITLE
Add `AssertThatEqualsDetector`

### DIFF
--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
@@ -1,0 +1,134 @@
+package com.jzbrooks.assertk.lint.checks
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.skipParenthesizedExprDown
+import java.util.EnumSet
+
+class AssertThatEqualsDetector :
+    Detector(),
+    SourceCodeScanner {
+    override fun getApplicableMethodNames(): List<String> = listOf("equals")
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: PsiMethod,
+    ) {
+        if (!context.isTestSource) return
+        if (node.valueArgumentCount != 1) return
+        if (!isAssertkAssertReceiver(context, node)) return
+
+        val argText =
+            node.valueArguments
+                .first()
+                .sourcePsi
+                ?.text ?: "..."
+        val receiverText =
+            node.receiver
+                ?.skipParenthesizedExprDown()
+                ?.sourcePsi
+                ?.text
+                ?.trim()
+                ?.takeUnless { it.contains('\n') }
+        val originalCallText = receiverText?.let { "$it.equals($argText)" } ?: "equals($argText)"
+
+        context.report(
+            ISSUE,
+            node,
+            context.getLocation(node),
+            "Replace `$originalCallText` with `assertThat(...).isEqualTo(...)`.",
+            buildFix(context, node),
+        )
+    }
+
+    private fun isAssertkAssertReceiver(
+        context: JavaContext,
+        node: UCallExpression,
+    ): Boolean {
+        val receiverExpr = node.receiver?.skipParenthesizedExprDown()
+
+        if (receiverExpr != null) {
+            val receiverType = receiverExpr.getExpressionType() ?: return false
+            val receiverClass = context.evaluator.getTypeClass(receiverType) ?: return false
+            return context.evaluator.extendsClass(receiverClass, ASSERTK_ASSERT_FQCN, false)
+        }
+
+        var cursor: UElement? = node.uastParent
+        while (cursor != null) {
+            if (cursor is ULambdaExpression) {
+                val enclosingCall = cursor.uastParent as? UCallExpression
+                val callReceiver = enclosingCall?.receiver?.skipParenthesizedExprDown()
+                if (callReceiver != null) {
+                    val receiverType = callReceiver.getExpressionType() ?: break
+                    val receiverClass = context.evaluator.getTypeClass(receiverType) ?: break
+                    return context.evaluator.extendsClass(receiverClass, ASSERTK_ASSERT_FQCN, false)
+                }
+                break
+            }
+            cursor = cursor.uastParent
+        }
+
+        return false
+    }
+
+    private fun buildFix(
+        context: JavaContext,
+        node: UCallExpression,
+    ): LintFix? {
+        val argument =
+            node.valueArguments
+                .firstOrNull()
+                ?.sourcePsi
+                ?.text ?: return null
+
+        return fix()
+            .name("Replace equals with isEqualTo")
+            .replace()
+            .range(
+                context.getCallLocation(
+                    call = node,
+                    includeReceiver = false,
+                    includeArguments = true,
+                ),
+            ).with("isEqualTo($argument)")
+            .imports("assertk.assertions.isEqualTo")
+            .reformat(true)
+            .build()
+    }
+
+    companion object {
+        @JvmField
+        val ISSUE: Issue =
+            Issue.create(
+                id = "AssertThatEqualsUsage",
+                briefDescription = "Use isEqualTo assertions instead of equals",
+                explanation = (
+                    "Calling `equals` on an `assertk.Assert` receiver does not " +
+                        "perform an assertion and can let tests pass unexpectedly. " +
+                        "Replace it with `isEqualTo`."
+                ),
+                category = Category.CORRECTNESS,
+                priority = 6,
+                severity = Severity.ERROR,
+                implementation =
+                    Implementation(
+                        AssertThatEqualsDetector::class.java,
+                        EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                    ),
+            )
+
+        private const val ASSERTK_ASSERT_FQCN = "assertk.Assert"
+    }
+}

--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
@@ -9,10 +9,10 @@ import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiTypes
 import org.jetbrains.uast.UCallExpression
-import org.jetbrains.uast.skipParenthesizedExprDown
 import java.util.EnumSet
 
 class AssertThatEqualsDetector :
@@ -30,25 +30,11 @@ class AssertThatEqualsDetector :
         if (method.returnType != PsiTypes.booleanType()) return
         if (!isAssertkAssertReceiver(context, node)) return
 
-        val argText =
-            node.valueArguments
-                .first()
-                .sourcePsi
-                ?.text ?: "..."
-        val receiverText =
-            node.receiver
-                ?.skipParenthesizedExprDown()
-                ?.sourcePsi
-                ?.text
-                ?.trim()
-                ?.takeUnless { it.contains('\n') }
-        val originalCallText = receiverText?.let { "$it.equals($argText)" } ?: "equals($argText)"
-
         context.report(
             ISSUE,
             node,
             context.getLocation(node),
-            "Replace `$originalCallText` with `assertThat(...).isEqualTo(...)`.",
+            ISSUE.getBriefDescription(TextFormat.TEXT),
             buildFix(context, node),
         )
     }
@@ -72,7 +58,6 @@ class AssertThatEqualsDetector :
                 ?.text ?: return null
 
         return fix()
-            .name("Replace equals with isEqualTo")
             .replace()
             .range(
                 context.getCallLocation(
@@ -91,7 +76,7 @@ class AssertThatEqualsDetector :
         val ISSUE: Issue =
             Issue.create(
                 id = "AssertThatEqualsUsage",
-                briefDescription = "Use isEqualTo assertions instead of equals",
+                briefDescription = "Replace `Any.equals` with `Assert.isEqualTo`",
                 explanation = (
                     "Calling `equals` on an `assertk.Assert` receiver does not " +
                         "perform an assertion and can let tests pass unexpectedly. " +

--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetector.kt
@@ -10,9 +10,8 @@ import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiTypes
 import org.jetbrains.uast.UCallExpression
-import org.jetbrains.uast.UElement
-import org.jetbrains.uast.ULambdaExpression
 import org.jetbrains.uast.skipParenthesizedExprDown
 import java.util.EnumSet
 
@@ -28,6 +27,7 @@ class AssertThatEqualsDetector :
     ) {
         if (!context.isTestSource) return
         if (node.valueArgumentCount != 1) return
+        if (method.returnType != PsiTypes.booleanType()) return
         if (!isAssertkAssertReceiver(context, node)) return
 
         val argText =
@@ -57,30 +57,8 @@ class AssertThatEqualsDetector :
         context: JavaContext,
         node: UCallExpression,
     ): Boolean {
-        val receiverExpr = node.receiver?.skipParenthesizedExprDown()
-
-        if (receiverExpr != null) {
-            val receiverType = receiverExpr.getExpressionType() ?: return false
-            val receiverClass = context.evaluator.getTypeClass(receiverType) ?: return false
-            return context.evaluator.extendsClass(receiverClass, ASSERTK_ASSERT_FQCN, false)
-        }
-
-        var cursor: UElement? = node.uastParent
-        while (cursor != null) {
-            if (cursor is ULambdaExpression) {
-                val enclosingCall = cursor.uastParent as? UCallExpression
-                val callReceiver = enclosingCall?.receiver?.skipParenthesizedExprDown()
-                if (callReceiver != null) {
-                    val receiverType = callReceiver.getExpressionType() ?: break
-                    val receiverClass = context.evaluator.getTypeClass(receiverType) ?: break
-                    return context.evaluator.extendsClass(receiverClass, ASSERTK_ASSERT_FQCN, false)
-                }
-                break
-            }
-            cursor = cursor.uastParent
-        }
-
-        return false
+        val clazz = context.evaluator.getTypeClass(node.receiverType)
+        return context.evaluator.inheritsFrom(clazz, ASSERTK_ASSERT_FQCN)
     }
 
     private fun buildFix(

--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertkIssueRegistry.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertkIssueRegistry.kt
@@ -8,6 +8,7 @@ class AssertkIssueRegistry : IssueRegistry() {
     override val issues =
         listOf(
             AssertJDetector.ISSUE,
+            AssertThatEqualsDetector.ISSUE,
             BooleanExpressionSubjectDetector.NULL_EXPR_ISSUE,
             BooleanExpressionSubjectDetector.EQUALITY_EXPR_ISSUE,
             CollectionAssertionDetector.SIZE_READ_ISSUE,

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
@@ -240,4 +240,33 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
 +    assertThat(1).isEqualTo(1)""",
             )
     }
+
+    @Test
+    fun `does not report extension function named equals returning unit`() {
+        val code =
+            """
+            package clean
+
+            import assertk.Assert
+            import assertk.assertThat
+
+            fun Assert<Int>.equals(somethingElse: Int) {
+
+            }
+
+            fun test() {
+                assertThat(1).equals(somethingElse = 1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
 }

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
@@ -33,7 +33,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expect(
-                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace assertThat(1).equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace Any.equals with Assert.isEqualTo [AssertThatEqualsUsage]
     assertThat(1).equals(1)
     ~~~~~~~~~~~~~~~~~~~~~~~
 1 error""",
@@ -112,7 +112,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expect(
-                """test/kotlin/test/pkg/UnitTestKotlin.kt:4: Error: Replace assertk.assertThat(1).equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:4: Error: Replace Any.equals with Assert.isEqualTo [AssertThatEqualsUsage]
     assertk.assertThat(1).equals(1)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1 error""",
@@ -144,7 +144,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expect(
-                """test/kotlin/test/pkg/UnitTestKotlin.kt:9: Error: Replace tmp.equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:9: Error: Replace Any.equals with Assert.isEqualTo [AssertThatEqualsUsage]
     tmp.equals(1)
     ~~~~~~~~~~~~~
 1 error""",
@@ -173,7 +173,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expect(
-                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace item.equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace Any.equals with Assert.isEqualTo [AssertThatEqualsUsage]
     item.equals(1)
     ~~~~~~~~~~~~~~
 1 error""",
@@ -203,7 +203,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expect(
-                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace Any.equals with Assert.isEqualTo [AssertThatEqualsUsage]
         equals(1)
         ~~~~~~~~~
 1 error""",
@@ -232,7 +232,7 @@ class AssertThatEqualsDetectorTest : LintDetectorTest() {
                 *ASSERTK_STUBS,
             ).run()
             .expectFixDiffs(
-                """Fix for test/kotlin/test/pkg/UnitTestKotlin.kt line 6: Replace equals with isEqualTo:
+                """Fix for test/kotlin/test/pkg/UnitTestKotlin.kt line 6: Replace with isEqualTo(1):
 @@ -3,0 +4 @@
 +import assertk.assertions.isEqualTo
 @@ -6 +7 @@

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/AssertThatEqualsDetectorTest.kt
@@ -1,0 +1,243 @@
+package com.jzbrooks.assertk.lint.checks
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class AssertThatEqualsDetectorTest : LintDetectorTest() {
+    override fun getDetector() = AssertThatEqualsDetector()
+
+    override fun getIssues() = listOf(AssertThatEqualsDetector.ISSUE)
+
+    @Test
+    fun `reports assertThat equals usage`() {
+        val code =
+            """
+            package clean
+
+            import assertk.assertThat
+
+            fun test() {
+                assertThat(1).equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace assertThat(1).equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+    assertThat(1).equals(1)
+    ~~~~~~~~~~~~~~~~~~~~~~~
+1 error""",
+            )
+    }
+
+    @Test
+    fun `does not report isEqualTo usage`() {
+        val code =
+            """
+            package clean
+
+            import assertk.assertThat
+            import assertk.assertions.isEqualTo
+
+            fun test() {
+                assertThat(1).isEqualTo(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `does not report non assertk equals usage`() {
+        val code =
+            """
+            package clean
+
+            class Wrapper {
+                fun equals(other: Any?) = true
+            }
+
+            fun assertThat(value: Int) = Wrapper()
+
+            fun test() {
+                assertThat(1).equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `reports fully qualified assertk call`() {
+        val code =
+            """
+            package clean
+
+            fun test() {
+                assertk.assertThat(1).equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:4: Error: Replace assertk.assertThat(1).equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+    assertk.assertThat(1).equals(1)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1 error""",
+            )
+    }
+
+    @Test
+    fun `reports chained assertk assertion equals usage`() {
+        val code =
+            """
+            package clean
+
+            import assertk.assertThat
+
+            fun test() {
+                val tmp: assertk.Assert<Int> = assertThat(1)
+                    .isNotNull()
+                    .isInstanceOf(Int::class.java)
+                tmp.equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:9: Error: Replace tmp.equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+    tmp.equals(1)
+    ~~~~~~~~~~~~~
+1 error""",
+            )
+    }
+
+    @Test
+    fun `reports equals on Assert value`() {
+        val code =
+            """
+            package clean
+            import assertk.assertThat
+
+            fun test() {
+                val item = assertThat(1)
+                item.equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace item.equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+    item.equals(1)
+    ~~~~~~~~~~~~~~
+1 error""",
+            )
+    }
+
+    @Test
+    fun `reports equals inside scope lambda on assertk receiver`() {
+        val code =
+            """
+            package clean
+            import assertk.assertThat
+
+            fun test() {
+                assertThat(1).run {
+                    equals(1)
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """test/kotlin/test/pkg/UnitTestKotlin.kt:6: Error: Replace equals(1) with assertThat(...).isEqualTo(...). [AssertThatEqualsUsage]
+        equals(1)
+        ~~~~~~~~~
+1 error""",
+            )
+    }
+
+    @Test
+    fun `quick fix replaces equals with isEqualTo`() {
+        val code =
+            """
+            package clean
+
+            import assertk.assertThat
+
+            fun test() {
+                assertThat(1).equals(1)
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectFixDiffs(
+                """Fix for test/kotlin/test/pkg/UnitTestKotlin.kt line 6: Replace equals with isEqualTo:
+@@ -3,0 +4 @@
++import assertk.assertions.isEqualTo
+@@ -6 +7 @@
+-    assertThat(1).equals(1)
++    assertThat(1).isEqualTo(1)""",
+            )
+    }
+}

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/Stubs.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/Stubs.kt
@@ -8,7 +8,9 @@ val assertkStub =
     package assertk
 
     class Assert<T> {
+        override fun equals(other: Any?): Boolean {
 
+        }
     }
 
     fun <T> assertThat(subject: T?): Assert<T> {


### PR DESCRIPTION
It's possible to use `.equals` on an assertion accidentally when you should use `.isEqualTo`. Doing so would simply be calling the Kotlin equality checker, and would never fail the test:

```kotlin
assertThat(0).equals(1) // returns false, but doesn't fail
assertThat(0).isEqualTo(1) // fails
```

This adds a lint rule to catch this scenario. It works by detecting any usage of the `equals` function on an instance of an `Assert<*>`. I don't think there's really ever a reason you'd want to do that intentionally.