### PR TITLE
Add SingleAssertionDetector

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,7 @@
   "permissions": {
     "allow": [
       "Bash(./gradlew build)",
-      "Bash(./gradlew test)",
+      "Bash(./gradlew *test *)",
       "Bash(./gradlew *check)",
       "Bash(./gradlew *assemble)",
       "Bash(./gradlew *classes)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * _AssertThatEqualsDetector_ detects `Any.equals` calls on assertion subjects which will never fail tests
+* _SingleAssertionDetector_ encourages `single()` over combining `hasSize(1)` with `index(0)` or `first()` inside `all { }`
 
 ### Changed
 

--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertkIssueRegistry.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/AssertkIssueRegistry.kt
@@ -18,6 +18,7 @@ class AssertkIssueRegistry : IssueRegistry() {
             MapAssertionDetector.DIRECT_READ_ISSUE,
             MapAssertionDetector.KEYS_SET_ABSENT_ISSUE,
             MapAssertionDetector.KEYS_SET_PRESENT_ISSUE,
+            SingleAssertionDetector.ISSUE,
             TestFrameworkAssertionDetector.ISSUE,
             TryCatchDetector.ISSUE,
             UnusedAssertionDetector.ISSUE,

--- a/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/SingleAssertionDetector.kt
+++ b/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/SingleAssertionDetector.kt
@@ -1,0 +1,147 @@
+package com.jzbrooks.assertk.lint.checks
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiMethod
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.uast.UBlockExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.ULambdaExpression
+import org.jetbrains.uast.ULiteralExpression
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UReturnExpression
+import org.jetbrains.uast.skipParenthesizedExprDown
+import java.util.EnumSet
+
+class SingleAssertionDetector :
+    Detector(),
+    SourceCodeScanner {
+    override fun getApplicableMethodNames(): List<String> = listOf("all")
+
+    override fun visitMethodCall(
+        context: JavaContext,
+        node: UCallExpression,
+        method: PsiMethod,
+    ) {
+        if (!context.isTestSource) return
+        if (context.uastFile?.lang != KotlinLanguage.INSTANCE) return
+        if (method.containingClass?.qualifiedName?.startsWith("assertk.") != true) return
+
+        val lambda =
+            node.valueArguments.filterIsInstance<ULambdaExpression>().firstOrNull() ?: return
+        val body = lambda.body as? UBlockExpression ?: return
+
+        val statements = body.expressions.map { it.unwrap() }
+        if (statements.size != 2) return
+
+        var hasSizeCall: UCallExpression? = null
+        var transformExpr: UQualifiedReferenceExpression? = null
+
+        for (statement in statements) {
+            when {
+                statement is UCallExpression &&
+                    statement.methodIdentifier?.name == "hasSize" -> {
+                    hasSizeCall = statement
+                }
+
+                statement is UQualifiedReferenceExpression -> {
+                    transformExpr = statement
+                }
+            }
+        }
+
+        if (hasSizeCall == null || transformExpr == null) return
+
+        val hasSizeArg = hasSizeCall.valueArguments.firstOrNull() as? ULiteralExpression ?: return
+        if (hasSizeArg.value != 1) return
+
+        val transformCall = transformExpr.deepestReceiver as? UCallExpression ?: return
+        val transformName = transformCall.methodIdentifier?.name
+
+        val isApplicableTransform =
+            when (transformName) {
+                "first" -> true
+                "index" -> {
+                    val indexArg = transformCall.valueArguments.firstOrNull() as? ULiteralExpression
+                    indexArg?.value == 0
+                }
+
+                else -> false
+            }
+
+        if (!isApplicableTransform) return
+
+        val selectors = mutableListOf<String>()
+        var current: UExpression = transformExpr
+        while (current is UQualifiedReferenceExpression) {
+            val selectorText = current.selector.sourcePsi?.text ?: return
+            selectors.add(0, selectorText)
+            current = current.receiver.skipParenthesizedExprDown()
+        }
+        val restText = selectors.joinToString(".")
+
+        val callLocation =
+            context.getCallLocation(
+                node,
+                includeReceiver = false,
+                includeArguments = true,
+            )
+
+        val quickFix =
+            fix()
+                .replace()
+                .imports("assertk.assertions.single")
+                .reformat(true)
+                .range(callLocation)
+                .with("single().$restText")
+                .build()
+
+        context.report(
+            ISSUE,
+            node,
+            callLocation,
+            ISSUE.getBriefDescription(TextFormat.TEXT),
+            quickFix,
+        )
+    }
+
+    private fun UExpression.unwrap(): UExpression {
+        var current: UExpression = this
+        while (true) {
+            current = current.skipParenthesizedExprDown()
+            val returnValue = (current as? UReturnExpression)?.returnExpression ?: break
+            current = returnValue
+        }
+        return current
+    }
+
+    companion object {
+        @JvmField
+        val ISSUE: Issue =
+            Issue.create(
+                id = "UseSingleAssertion",
+                briefDescription = "Use single assertion for one-element collection assertions",
+                explanation = """
+                    assertk's `single()` asserts that the collection has exactly one element \
+                    and transforms the assertion subject to that element. Prefer `single()` \
+                    over combining `hasSize(1)` with `index(0)` or `first()` inside an `all { }` block.
+                """,
+                category = Category.PRODUCTIVITY,
+                priority = 4,
+                severity = Severity.WARNING,
+                implementation =
+                    Implementation(
+                        SingleAssertionDetector::class.java,
+                        EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                    ),
+            )
+    }
+}

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/SingleAssertionDetectorTest.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/SingleAssertionDetectorTest.kt
@@ -1,0 +1,373 @@
+package com.jzbrooks.assertk.lint.checks
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SingleAssertionDetectorTest : LintDetectorTest() {
+    override fun getDetector() = SingleAssertionDetector()
+
+    override fun getIssues() =
+        listOf(
+            SingleAssertionDetector.ISSUE,
+        )
+
+    @Test
+    fun `single assertion reports clean`() {
+        val code =
+            """
+            package clean
+
+            import assertk.assertThat
+            import assertk.assertions.isEqualTo
+            import assertk.assertions.single
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).single().isEqualTo("a")
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `hasSize one and index zero pattern is reported`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        hasSize(1)
+                        index(0).isEqualTo("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """
+                test/kotlin/test/pkg/UnitTestKotlin.kt:13: Warning: Use single assertion for one-element collection assertions [UseSingleAssertion]
+                        assertThat(list).all {
+                                         ^
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `hasSize one and first pattern is reported`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.first
+            import assertk.assertions.hasSize
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        hasSize(1)
+                        first().isEqualTo("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """
+                test/kotlin/test/pkg/UnitTestKotlin.kt:13: Warning: Use single assertion for one-element collection assertions [UseSingleAssertion]
+                        assertThat(list).all {
+                                         ^
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `reversed order pattern is reported`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        index(0).isEqualTo("a")
+                        hasSize(1)
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expect(
+                """
+                test/kotlin/test/pkg/UnitTestKotlin.kt:13: Warning: Use single assertion for one-element collection assertions [UseSingleAssertion]
+                        assertThat(list).all {
+                                         ^
+                0 errors, 1 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `hasSize two reports clean`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a", "b")
+
+                    assertThat(list).all {
+                        hasSize(2)
+                        index(0).isEqualTo("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `non-zero index reports clean`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a", "b")
+
+                    assertThat(list).all {
+                        hasSize(2)
+                        index(1).isEqualTo("b")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `more than two statements reports clean`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.contains
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        hasSize(1)
+                        index(0).isEqualTo("a")
+                        contains("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectClean()
+    }
+
+    @Test
+    fun `hasSize one and index zero pattern is fixed`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.hasSize
+            import assertk.assertions.index
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        hasSize(1)
+                        index(0).isEqualTo("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectFixDiffs(
+                """
+                Fix for test/kotlin/test/pkg/UnitTestKotlin.kt line 13: Replace with single().isEqualTo("a"):
+                @@ -7,0 +8 @@
+                +import assertk.assertions.single
+                @@ -13,4 +14 @@
+                -        assertThat(list).all {
+                -            hasSize(1)
+                -            index(0).isEqualTo("a")
+                -        }
+                +        assertThat(list).single().isEqualTo("a")
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun `hasSize one and first pattern is fixed`() {
+        val code =
+            """
+            package clean
+
+            import assertk.all
+            import assertk.assertThat
+            import assertk.assertions.first
+            import assertk.assertions.hasSize
+            import assertk.assertions.isEqualTo
+
+            class TestingTesting {
+                fun testingTest() {
+                    val list: List<String> = listOf("a")
+
+                    assertThat(list).all {
+                        hasSize(1)
+                        first().isEqualTo("a")
+                    }
+                }
+            }
+            """.trimIndent()
+
+        lint()
+            .files(
+                kotlin(
+                    "test/kotlin/test/pkg/UnitTestKotlin.kt",
+                    code,
+                ),
+                *ASSERTK_STUBS,
+            ).run()
+            .expectFixDiffs(
+                """
+                Fix for test/kotlin/test/pkg/UnitTestKotlin.kt line 13: Replace with single().isEqualTo("a"):
+                @@ -7,0 +8 @@
+                +import assertk.assertions.single
+                @@ -13,4 +14 @@
+                -        assertThat(list).all {
+                -            hasSize(1)
+                -            first().isEqualTo("a")
+                -        }
+                +        assertThat(list).single().isEqualTo("a")
+                """.trimIndent(),
+            )
+    }
+}

--- a/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/Stubs.kt
+++ b/checks/src/test/kotlin/com/jzbrooks/assertk/lint/checks/Stubs.kt
@@ -16,6 +16,10 @@ val assertkStub =
 
     }
 
+    fun <T> Assert<T>.all(body: Assert<T>.() -> Unit) {
+
+    }
+
     fun fail() {
         throw java.lang.AssertionError("fail!")
     }
@@ -70,6 +74,18 @@ val assertkIterableStub =
     }
 
     fun <T> assertk.Assert<Array<T>>.index(index: Int): Assert<T> {
+
+    }
+
+    fun <T> Assert<List<T>>.index(index: Int): Assert<T> {
+
+    }
+
+    fun <T> Assert<Iterable<T>>.first(): Assert<T> {
+
+    }
+
+    fun <T> Assert<Iterable<T>>.single(): Assert<T> {
 
     }
     """.trimIndent()

--- a/docs/checks/index.md
+++ b/docs/checks/index.md
@@ -1,6 +1,6 @@
 # Checks
 
-assertk-lint ships **14 issues** across 11 detectors. All detectors run only
+assertk-lint ships **15 issues** across 12 detectors. All detectors run only
 against Kotlin test sources.
 
 ## Errors
@@ -23,6 +23,7 @@ where the surrounding test will silently pass even though it shouldn't.
 | [`EqualityComparisonAssertion`](equality-comparison.md) | `assertThat(a == b)` / `assertThat(a != b)` | Yes |
 | [`CollectionSizeAssertion`](collection-size.md) | `assertThat(list.size).isEqualTo(n)` &mdash; use `hasSize(n)` | Yes |
 | [`UseIndexAssertion`](use-index.md) | `assertThat(list[i])` &mdash; use `assertThat(list).index(i)` | Yes |
+| [`UseSingleAssertion`](use-single.md) | `all { hasSize(1); first()... }` &mdash; use `single()` | Yes |
 | [`MapValueAssertion`](map-value.md) | `assertThat(map[k])` &mdash; use `assertThat(map).key(k)` | Yes |
 | [`KeySetPresentAssertion`](key-set-present.md) | `assertThat(map.keys).contains(k)` &mdash; use `key(k)` | Yes |
 | [`KeySetAbsentAssertion`](key-set-absent.md) | `assertThat(map.keys).doesNotContain(k)` &mdash; use `doesNotContainKey(k)` | Yes |

--- a/docs/checks/use-single.md
+++ b/docs/checks/use-single.md
@@ -1,0 +1,77 @@
+# UseSingleAssertion
+
+**Issue ID** `UseSingleAssertion` ·
+**Severity** `Warning` ·
+**Category** `Productivity` ·
+**Default** on
+
+Flags the `assertk.all { hasSize(1); first()... }` (and the `index(0)`
+equivalent) pattern where assertk's `single()` should be used.
+
+## Why
+
+`Assert<List<T>>.single()` asserts that the collection has exactly one element
+*and* transforms the subject to that element. Doing it by hand &mdash;
+`hasSize(1)` plus `first()`/`index(0)` inside an `all { }` block &mdash; is
+two assertions where one will do, and the chained form reads more naturally.
+
+The detector fires only on the simple two-statement shape inside an
+`all { }` block from `assertk`:
+
+- `hasSize(1)` paired with `first().<something>`, **or**
+- `hasSize(1)` paired with `index(0).<something>`.
+
+The order doesn't matter. Anything else &mdash; `hasSize(2)`, `index(1)`,
+extra statements in the block &mdash; is left alone.
+
+## Example
+
+=== "Flagged"
+
+    ```kotlin
+    import assertk.all
+    import assertk.assertThat
+    import assertk.assertions.hasSize
+    import assertk.assertions.index
+    import assertk.assertions.isEqualTo
+
+    fun onlyElement() {
+        val list: List<String> = listOf("a")
+        assertThat(list).all {
+            hasSize(1)
+            index(0).isEqualTo("a")
+        }
+    }
+    ```
+
+=== "Preferred"
+
+    ```kotlin
+    import assertk.assertThat
+    import assertk.assertions.isEqualTo
+    import assertk.assertions.single
+
+    fun onlyElement() {
+        val list: List<String> = listOf("a")
+        assertThat(list).single().isEqualTo("a")
+    }
+    ```
+
+The `first()` form is recognised the same way:
+
+```kotlin
+assertThat(list).all {
+    hasSize(1)
+    first().isEqualTo("a") // also flagged
+}
+```
+
+## Quick fix
+
+Yes &mdash; the IDE collapses the entire `all { }` block to
+`single().<chained assertion>`, preserving whatever assertion was applied to
+the element, and adds the `assertk.assertions.single` import.
+
+## Source
+
+[`SingleAssertionDetector.kt`](https://github.com/jzbrooks/assertk-lint/blob/master/checks/src/main/kotlin/com/jzbrooks/assertk/lint/checks/SingleAssertionDetector.kt)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - EqualityComparisonAssertion: checks/equality-comparison.md
       - CollectionSizeAssertion: checks/collection-size.md
       - UseIndexAssertion: checks/use-index.md
+      - UseSingleAssertion: checks/use-single.md
       - MapValueAssertion: checks/map-value.md
       - KeySetPresentAssertion: checks/key-set-present.md
       - KeySetAbsentAssertion: checks/key-set-absent.md


### PR DESCRIPTION
This assertion can be replaced with a single assertion `single`, which asserts a single item in the collection and can then be used to make assertions against that element.

```kotlin
assertThat(list).all {
    hasSize(1)
    index(0).isEqualTo("a")
}
```

Fixes #135